### PR TITLE
Show NPC progress on the UI

### DIFF
--- a/cow-game/src/cow-game-babylon/babylon-scene.ts
+++ b/cow-game/src/cow-game-babylon/babylon-scene.ts
@@ -21,6 +21,7 @@ import { createRigidHorsesRenderer } from "./rigid-horses-renderer";
 import { createNpcRenderer } from "./npc-renderer";
 import { createCowGameAssetsManager } from "./assets-manager";
 import { createGridRenderer } from "./grid-renderer";
+import { INpc } from "../cow-game-domain/cow-game-model";
 
 // TODO:
 // https://playground.babylonjs.com/#CSPJ7A#3
@@ -87,6 +88,11 @@ export async function createBabylonScene(
 
   const npcRenderer = createNpcRenderer(scene, gameController, ground);
 
+  function getNpcDistanceToHome(npcId: INpc["id"]) {
+    // TODO:
+    return Math.random();
+  }
+
   function dispose() {
     npcRenderer.dispose();
     horseRenderer.dispose();
@@ -98,5 +104,5 @@ export async function createBabylonScene(
 
   await assetsManager.readyPromise;
 
-  return { scene, dispose };
+  return { scene, dispose, simulation: { getNpcDistanceToHome } };
 }

--- a/cow-game/src/cow-game-babylon/babylon-scene.ts
+++ b/cow-game/src/cow-game-babylon/babylon-scene.ts
@@ -88,11 +88,6 @@ export async function createBabylonScene(
 
   const npcRenderer = createNpcRenderer(scene, gameController, ground);
 
-  function getNpcDistanceToHome(npcId: INpc["id"]) {
-    // TODO:
-    return Math.random();
-  }
-
   function dispose() {
     npcRenderer.dispose();
     horseRenderer.dispose();
@@ -104,5 +99,9 @@ export async function createBabylonScene(
 
   await assetsManager.readyPromise;
 
-  return { scene, dispose, simulation: { getNpcDistanceToHome } };
+  return {
+    scene,
+    dispose,
+    simulation: { getNpcPosition: npcRenderer.getNpcPosition },
+  };
 }

--- a/cow-game/src/cow-game-babylon/npc-renderer.ts
+++ b/cow-game/src/cow-game-babylon/npc-renderer.ts
@@ -97,7 +97,7 @@ export function createNpcRenderer(
           npcSpawnedEvent.npc.id
         )
       );
-    }, npcSpawnedEvent.npc.lifespan * 1000);
+    }, (npcSpawnedEvent.npc.deathTime-npcSpawnedEvent.npc.spawnTime) * 1000);
 
     return {
       ...cube,

--- a/cow-game/src/cow-game-domain/cow-game-commands.ts
+++ b/cow-game/src/cow-game-domain/cow-game-commands.ts
@@ -99,3 +99,9 @@ export function notifyNpcExploded(npcId: number): Command {
     emitEvent({ type: "INpcExploded", npc });
   };
 }
+
+export function focusOnHouse(housePosition: IPosition): Command {
+  return function focusOnHouse({ model }, emitEvent) {
+    emitEvent({ type: "IHouseFocused", housePosition });
+  };
+}

--- a/cow-game/src/cow-game-domain/cow-game-events.ts
+++ b/cow-game/src/cow-game-domain/cow-game-events.ts
@@ -32,10 +32,16 @@ export interface INpcExploded {
   npc: INpc;
 }
 
+export interface IHouseFocused {
+  type: "IHouseFocused";
+  housePosition: IPosition;
+}
+
 export type Events =
   | INewGameStarted
   | IDestinationUpdated
   | IHorseSpawned
   | INpcSpawned
   | INpcArrivedAtHome
-  | INpcExploded;
+  | INpcExploded
+  | IHouseFocused;

--- a/cow-game/src/cow-game-domain/cow-game-logic.ts
+++ b/cow-game/src/cow-game-domain/cow-game-logic.ts
@@ -12,8 +12,8 @@ import {
 
 export const GameParams = {
   npcsToSpawn: 5,
-  npcLifespan: 10,
-  npcSpawnInterval: 1,
+  npcLifespan: 120,
+  npcSpawnInterval: 10,
 };
 
 export function createGrid(): IModel["grid"] {
@@ -68,6 +68,12 @@ export function createGrid(): IModel["grid"] {
 export function* enumerateHabitableHouses(grid: IModel["grid"]) {
   for (var y = 0; y < grid.height; y++) {
     for (var x = 0; x < grid.width; x++) {
+      // Do not allow NPCs to live in the bottom edges; it's too close to spawn
+      const isTooCloseToSpawn = x < 2 || y < 2;
+      if (isTooCloseToSpawn) {
+        continue;
+      }
+
       const isHouse = grid.cells[y * grid.width + x].house;
       if (isHouse) {
         yield { x, y };
@@ -214,4 +220,14 @@ export function findPath(
       to: destination,
     });
   }
+}
+
+export function calculateNpcDistanceToHome(
+  npcPosition: IPosition,
+  home: IPosition
+) {
+  const dx = home.x - npcPosition.x;
+  const dy = home.y - npcPosition.y;
+  const d = Math.sqrt(dx * dx + dy * dy) / 5;
+  return d < 0 ? 0 : d > 1 ? 1 : d;
 }

--- a/cow-game/src/cow-game-domain/cow-game-logic.ts
+++ b/cow-game/src/cow-game-domain/cow-game-logic.ts
@@ -12,7 +12,8 @@ import {
 
 export const GameParams = {
   npcsToSpawn: 5,
-  NpcLifespan: 60,
+  npcLifespan: 10,
+  npcSpawnInterval: 1,
 };
 
 export function createGrid(): IModel["grid"] {
@@ -79,17 +80,19 @@ export function* generateNpcs(
   grid: IModel["grid"],
   homes: IPosition[],
   spawnpoints: IPosition[]
-) {
+): IterableIterator<INpc> {
   for (var i = 0; i < homes.length; i++) {
     const spawn = spawnpoints[i % spawnpoints.length];
     const home = homes[i];
     const route = findPath(grid, spawn, home);
+    const spawnTime = (i + 1) * GameParams.npcSpawnInterval;
     yield {
       id: i,
       home,
-      lifespan: GameParams.NpcLifespan,
       spawn,
       route,
+      spawnTime,
+      deathTime: spawnTime + GameParams.npcLifespan,
     };
   }
 }

--- a/cow-game/src/cow-game-domain/cow-game-model.ts
+++ b/cow-game/src/cow-game-domain/cow-game-model.ts
@@ -8,7 +8,8 @@ export interface INpc {
   spawn: IPosition;
   home: IPosition;
   route: IPosition[];
-  lifespan: number;
+  spawnTime: number;
+  deathTime: number;
 }
 
 export enum TerrainTypes {

--- a/cow-game/src/cow-game-domain/cow-game-reduce.ts
+++ b/cow-game/src/cow-game-domain/cow-game-reduce.ts
@@ -1,4 +1,5 @@
 import { AppError } from "../reusable/app-errors";
+import { assertUnreachable } from "../reusable/assertions";
 import type { Events } from "./cow-game-events";
 import type { IModel } from "./cow-game-model";
 
@@ -26,7 +27,7 @@ export function reduce(model: IModel, ev: Events): IModel {
       const { npc } = ev;
       return {
         ...model,
-        npcsToSpawn: model.npcsToSpawn.filter(i => i.id !== npc.id),
+        npcsToSpawn: model.npcsToSpawn.filter((i) => i.id !== npc.id),
         npcs: model.npcs.concat(npc),
       };
     }
@@ -55,6 +56,14 @@ export function reduce(model: IModel, ev: Events): IModel {
         housesWon: [...model.housesWon, npc.home],
       };
     }
+
+    case "IHouseFocused": {
+      return model;
+    }
+
+    default:
+      // A compilation error here means there's a missing case up there ☝️
+      assertUnreachable(ev);
   }
 
   throw new AppError("An event was not handled in the reducer.", { model, ev });

--- a/cow-game/src/cow-game-domain/cow-game-simulation.ts
+++ b/cow-game/src/cow-game-domain/cow-game-simulation.ts
@@ -1,4 +1,4 @@
-import { INpc } from "./cow-game-model";
+import { INpc, IPosition } from "./cow-game-model";
 
 /**
  * Allows the UI to query the current game world in real-time.
@@ -8,5 +8,5 @@ export interface CowGameSimulation {
    * Gets the normalised distance of the NPC to it's home; with 1 meaning it's at the bus stop and 0 meaning it's at home.
    * @param npcId
    */
-  getNpcDistanceToHome(npcId: INpc["id"]): number;
+   getNpcPosition(npcId: INpc["id"]): IPosition;
 }

--- a/cow-game/src/cow-game-domain/cow-game-simulation.ts
+++ b/cow-game/src/cow-game-domain/cow-game-simulation.ts
@@ -1,0 +1,12 @@
+import { INpc } from "./cow-game-model";
+
+/**
+ * Allows the UI to query the current game world in real-time.
+ */
+export interface CowGameSimulation {
+  /**
+   * Gets the normalised distance of the NPC to it's home; with 1 meaning it's at the bus stop and 0 meaning it's at home.
+   * @param npcId
+   */
+  getNpcDistanceToHome(npcId: INpc["id"]): number;
+}

--- a/cow-game/src/cow-game-ui/cow-game-ui.css
+++ b/cow-game/src/cow-game-ui/cow-game-ui.css
@@ -15,3 +15,7 @@
 .bottom-panel > * {
   pointer-events: initial;
 }
+
+.npcs-panel button {
+  display: block;
+}

--- a/cow-game/src/cow-game-ui/cow-game-ui.css
+++ b/cow-game/src/cow-game-ui/cow-game-ui.css
@@ -16,6 +16,10 @@
   pointer-events: initial;
 }
 
-.npcs-panel button {
+.houses-panel {
+  top: 10rem;
+}
+
+.houses-panel button {
   display: block;
 }

--- a/cow-game/src/cow-game-ui/cow-game-ui.tsx
+++ b/cow-game/src/cow-game-ui/cow-game-ui.tsx
@@ -9,13 +9,16 @@ import {
 import { GameController } from "../cow-game-domain/cow-game-controller";
 import { enumerateHabitableHouses } from "../cow-game-domain/cow-game-logic";
 import { IModel, IPosition } from "../cow-game-domain/cow-game-model";
+import { CowGameSimulation } from "../cow-game-domain/cow-game-simulation";
 
 import "./cow-game-ui.css";
 
 export function CowGameUi({
   gameController,
+  simulation
 }: {
   gameController: GameController;
+  simulation: CowGameSimulation | null;
 }) {
   const [model, setModel] = useState<IModel | null>(null);
 
@@ -27,7 +30,7 @@ export function CowGameUi({
     return unsubscriber;
   }, [gameController]);
 
-  const gameTime = useGameTime(gameController);
+  const gameTime = useGameTime(gameController, 100);
 
   if (!model) {
     return null;
@@ -64,6 +67,7 @@ export function CowGameUi({
         onClick={() => onClickHouseButton(house)}
       >
         🚌 &nbsp;&nbsp;&nbsp;
+        {npc && simulation?.getNpcDistanceToHome(npc.id).toString() || 'huh'}
         {npc &&
           getNpcEmoji(npc.deathTime - npc.spawnTime, gameTime - npc.spawnTime)}
         &nbsp;&nbsp;&nbsp; 🏡
@@ -90,7 +94,7 @@ export function CowGameUi({
   );
 }
 
-function useGameTime(gameController: GameController) {
+function useGameTime(gameController: GameController, intervalMsec: number) {
   const [startTime, setStartTime] = useState(0);
 
   useEffect(() => {
@@ -109,7 +113,7 @@ function useGameTime(gameController: GameController) {
   useEffect(() => {
     const n = setInterval(() => {
       setTime(Date.now());
-    }, 100);
+    }, intervalMsec);
     return () => clearInterval(n);
   }, []);
 

--- a/cow-game/src/cow-game-ui/cow-game-ui.tsx
+++ b/cow-game/src/cow-game-ui/cow-game-ui.tsx
@@ -21,6 +21,8 @@ export function CowGameUi({
     return unsubscriber;
   }, [gameController]);
 
+  const gameTime = useGameTime(gameController);
+
   if (!model) {
     return null;
   }
@@ -35,16 +37,66 @@ export function CowGameUi({
 
   return (
     <>
-    <div class="cow-game-ui">
-      <p>Houses won: {model.housesWon.length}</p>
-      <p>Houses lost: {model.housesLost.length}</p>
-      <p>Houses remaining: {model.housesRemaining}</p>
-      <p>Horses spawned: {model.horsesSpawned}</p>
-      <button onClick={onStartNewGame}>Start new game</button>
-    </div>
-    <div class="bottom-panel">
-      <button onClick={onClickSpawnHorse}>HORSE ME</button>
-    </div>
+      <div class="cow-game-ui">
+        <p>Houses won: {model.housesWon.length}</p>
+        <p>Houses lost: {model.housesLost.length}</p>
+        <p>Houses remaining: {model.housesRemaining}</p>
+        <p>Horses spawned: {model.horsesSpawned}</p>
+        <button onClick={onStartNewGame}>Start new game</button>
+      </div>
+      <div class="npcs-panel">
+        {model.npcs.map((npc) => (
+          <button key={npc.id}>
+            NPC {npc.id}{" "}
+            {getNpcEmoji(
+              npc.deathTime - npc.spawnTime,
+              gameTime - npc.spawnTime
+            )}{" "}
+            ({Math.trunc((npc.deathTime - gameTime) * 10) / 10})
+          </button>
+        ))}
+      </div>
+      <div class="bottom-panel">
+        <button onClick={onClickSpawnHorse}>HORSE ME</button>
+      </div>
     </>
   );
+}
+
+function useGameTime(gameController: GameController) {
+  const [startTime, setStartTime] = useState(0);
+
+  useEffect(() => {
+    const unsubscribe = gameController.subscribeEvents((ev) => {
+      switch (ev.event.type) {
+        case "INewGameStarted": {
+          setStartTime(Date.now());
+        }
+      }
+    });
+    return unsubscribe;
+  }, [gameController]);
+
+  const [time, setTime] = useState(0);
+
+  useEffect(() => {
+    const n = setInterval(() => {
+      setTime(Date.now());
+    }, 100);
+    return () => clearInterval(n);
+  }, []);
+
+  return (time - startTime) / 1000;
+}
+
+const Emojis = Array.from("😀🙂🤨😡🤬");
+
+function getNpcEmoji(npcLifespan: number, elapsed: number) {
+  const t = elapsed / npcLifespan;
+  if (t >= 1) {
+    return "🏆";
+  }
+  const c = t < 0 ? 0 : t > 1 ? 1 : t;
+  const e = Emojis[Math.trunc(c * Emojis.length)];
+  return e;
 }

--- a/cow-game/src/cow-game-ui/cow-game-ui.tsx
+++ b/cow-game/src/cow-game-ui/cow-game-ui.tsx
@@ -63,11 +63,12 @@ export function CowGameUi({
         key={`${house.x},${house.y}`}
         onClick={() => onClickHouseButton(house)}
       >
-        🏡
+        🚌 &nbsp;&nbsp;&nbsp;
         {npc &&
           getNpcEmoji(npc.deathTime - npc.spawnTime, gameTime - npc.spawnTime)}
-        {npcWon && "❌"}
-        {horseWon && "🏆"}
+        &nbsp;&nbsp;&nbsp; 🏡
+        {/* {npcWon && "❌"}
+        {horseWon && "🏆"} */}
       </button>
     ))
     .toArray();

--- a/cow-game/src/index.tsx
+++ b/cow-game/src/index.tsx
@@ -7,58 +7,77 @@ import "@babylonjs/core/Meshes/meshBuilder";
 import "@babylonjs/core/Debug/debugLayer";
 import "@babylonjs/inspector";
 
-import BabylonEngine from "./reusable/babylon/preact-babylon-engine/BabylonEngine";
+import BabylonEngine, {
+  DisposableEngine,
+} from "./reusable/babylon/preact-babylon-engine/BabylonEngine";
 import "./index.css";
 import { createBabylonScene } from "./cow-game-babylon/babylon-scene";
 import { createGameController } from "./cow-game-domain/cow-game-controller";
 import { startNpcSpawnerBehaviour } from "./cow-game-domain/cow-game-behaviours";
 import { startNewGame } from "./cow-game-domain/cow-game-commands";
 import { CowGameUi } from "./cow-game-ui/cow-game-ui";
+import { CowGameSimulation } from "./cow-game-domain/cow-game-simulation";
+import { INpc } from "./cow-game-domain/cow-game-model";
+import { useMemo, useState } from "preact/hooks";
 
 const controller = createGameController();
-
-async function createBabylonEngine(canvas: HTMLCanvasElement) {
-  const engine = new Engine(canvas, true);
-
-  const disposableScene = await createBabylonScene(engine, canvas, controller);
-
-  const wany = window as any;
-  wany.hax = {
-    ...wany.hax,
-    debug: () => (disposableScene.scene as any).debugLayer.show(),
-  };
-
-  // Can press ` to open the Babylon inspector
-  canvas.addEventListener("keyup", (ev) => {
-    if (ev.key === "`") {
-      disposableScene.scene.debugLayer.show({
-        globalRoot: document.body,
-      });
-    }
-  });
-
-  const disposeSpawnNpcBehaviour = startNpcSpawnerBehaviour(controller);
-
-  function dispose() {
-    disposeSpawnNpcBehaviour();
-    disposableScene.dispose();
-    engine.dispose();
-  }
-
-  controller.enqueueCommand(startNewGame(""));
-
-  return { engine, dispose };
-}
 
 const root = document.getElementById("root");
 if (!root) {
   throw new Error("Root element not found.");
 }
 
-render(
-  <>
-    <BabylonEngine engineFactory={createBabylonEngine} />
-    <CowGameUi gameController={controller} />
-  </>,
-  root
-);
+function App() {
+  const [simulation, setSimulation] = useState<CowGameSimulation | null>(null);
+
+  const createBabylonEngine = useMemo(
+    () => async (canvas: HTMLCanvasElement) => {
+      const engine = new Engine(canvas, true);
+
+      const disposableScene = await createBabylonScene(
+        engine,
+        canvas,
+        controller
+      );
+
+      const wany = window as any;
+      wany.hax = {
+        ...wany.hax,
+        debug: () => (disposableScene.scene as any).debugLayer.show(),
+      };
+
+      // Can press ` to open the Babylon inspector
+      canvas.addEventListener("keyup", (ev) => {
+        if (ev.key === "`") {
+          disposableScene.scene.debugLayer.show({
+            globalRoot: document.body,
+          });
+        }
+      });
+
+      const disposeSpawnNpcBehaviour = startNpcSpawnerBehaviour(controller);
+
+      function dispose() {
+        disposeSpawnNpcBehaviour();
+        disposableScene.dispose();
+        engine.dispose();
+      }
+
+      controller.enqueueCommand(startNewGame(""));
+
+      setSimulation(disposableScene.simulation);
+
+      return { engine, dispose };
+    },
+    []
+  );
+
+  return (
+    <>
+      <BabylonEngine engineFactory={createBabylonEngine} />
+      <CowGameUi gameController={controller} simulation={simulation} />
+    </>
+  );
+}
+
+render(<App />, root);

--- a/cow-game/src/index.tsx
+++ b/cow-game/src/index.tsx
@@ -37,8 +37,6 @@ async function createBabylonEngine(canvas: HTMLCanvasElement) {
     }
   });
 
-  controller.enqueueCommand(startNewGame(""));
-
   const disposeSpawnNpcBehaviour = startNpcSpawnerBehaviour(controller);
 
   function dispose() {
@@ -46,6 +44,9 @@ async function createBabylonEngine(canvas: HTMLCanvasElement) {
     disposableScene.dispose();
     engine.dispose();
   }
+
+  controller.enqueueCommand(startNewGame(""));
+
   return { engine, dispose };
 }
 

--- a/cow-game/src/reusable/assertions.ts
+++ b/cow-game/src/reusable/assertions.ts
@@ -58,3 +58,7 @@ export class AssertionError extends AppError {
     Object.setPrototypeOf(this, AssertionError.prototype);
   }
 }
+
+export function assertUnreachable(x: never): never {
+  throw new Error("Didn't expect to get here.");
+}

--- a/cow-game/src/reusable/babylon/follow-behaviour.ts
+++ b/cow-game/src/reusable/babylon/follow-behaviour.ts
@@ -3,22 +3,19 @@ import { Scene, Vector3 } from "@babylonjs/core";
 interface Options {
   /** If true, the initial distance from the follower to the followee will be maintained. In other words, it will "stay in formation." */
   useOffset: boolean;
-  /** Allows the caller to pause the follow behaviour on a frame-by-frame basis. */
-  isPaused: (() => boolean) | null;
   /** How "fast" the follower moves to the followee. There's no real intuition here, so just experiment. */
   aggressiveness: number;
 }
 
 const DefaultOptions: Options = {
   useOffset: false,
-  isPaused: null,
   aggressiveness: 0.5,
 };
 
 /**
  * A thing that has a position; thsi is necessary because Cameras and TransformNodes don't share a transform-like parent.
  */
-interface HasPosition {
+export interface HasPosition {
   readonly position: Vector3;
 }
 
@@ -26,14 +23,14 @@ interface HasPosition {
  * Starts an on-before-render process to have one object move towards another.
  * @param scene The scene the objects are in.
  * @param follower The object doing the following; this is the one that will be moved.
- * @param followee The object being followed.
+ * @param followee The object being followed, or a function to call every frame to compute the followee; return null to pause following.
  * @param options Optional optionses.
  * @returns An API for terminating the behaviour.
  */
 export function startFollowBehaviour(
   scene: Scene,
   follower: HasPosition,
-  followee: HasPosition,
+  followee: HasPosition | (() => HasPosition | null),
   options: Partial<Options> | null
 ) {
   const resolvedOptions = {
@@ -41,14 +38,22 @@ export function startFollowBehaviour(
     ...options,
   };
 
-  const offset = resolvedOptions.useOffset
-    ? follower.position.subtract(followee.position)
-    : Vector3.Zero();
+  var offset: Vector3 | null = null;
 
   function onBeforeRender() {
-    if (resolvedOptions.isPaused && resolvedOptions.isPaused()) return;
+    const resolvedFolowee =
+      typeof followee === "function" ? followee() : followee;
+    if (!resolvedFolowee) {
+      return;
+    }
 
-    const destination = followee.position.add(offset);
+    if (!offset) {
+      offset = resolvedOptions.useOffset
+        ? follower.position.subtract(resolvedFolowee.position)
+        : Vector3.Zero();
+    }
+
+    const destination = resolvedFolowee.position.add(offset);
     const diff = destination.subtract(follower.position);
     const deltaTime = scene.deltaTime / 1000;
     if (deltaTime) {


### PR DESCRIPTION
Introduces some new concepts.

**NPCs, their homes and their route is now predetermined**

This is so we can easily show the player's progress towards winning.

**Introduced CowGameSimulation**

The game model is event based, which isn't great for showing a UI for highly-dynamic things, e.g. NPC distance-to-home.

Emitting an "NPC moved" event every frame would be too spammy. Emitting the event periodically is too choppy. So instead, we introduce the idea that the UI can query the current simulation state (i.e. the game world) in real-time. This means the UI is in control of it's own frequency of updates.

**Can now compute the camera's follow target (or pause it) frame-by-frame**

This is used to focus on a house for a few seconds and then resume following the player as normal.